### PR TITLE
use generic docker sources, not harbor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM harbor.containers.wurnet.nl/proxy-cache/pandoc/latex:2.19.2-alpine@sha256:cc0228f2e6552683502692281bc2c0624ef3be175886ddd0279c2b9bfeb8c95a as build
+FROM pandoc/latex:2.19.2-alpine as build
 
 COPY . .
 WORKDIR /data/doc
 RUN  chmod +x compile.sh &&  sh compile.sh html
 # --- end of build ---
-FROM harbor.containers.wurnet.nl/proxy-cache/bitnami/nginx:1.22.1-debian-11-r31@sha256:998a477a61241f97f2a532e2669261328b978c37f8c82a9e8f4f63df337601de
+FROM nginx:1.29.5-alpine
 
-COPY --from=build /data/public/ /app
+COPY --from=build /data/public/ /usr/share/nginx/html
+RUN mkdir -p /var/cache/nginx \
+    /var/cache/nginx/client_temp \
+    /var/run \
+    && chown -R 1001:1001 /var/cache/nginx \
+    && chown -R 1001:1001 /run \
+    && chown -R 1001:1001 /usr/share/nginx/html
+
 USER 1001
 EXPOSE 8080
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;"] 


### PR DESCRIPTION
this uses generic docker image, so the build does not require wur-vpn
the problem with mermaid generating bad png images is not solved unfortunately